### PR TITLE
Links To RMA/Returns In Order Edit

### DIFF
--- a/app/overrides/admin/orders/add_rma_link_to_page_actions.rb
+++ b/app/overrides/admin/orders/add_rma_link_to_page_actions.rb
@@ -1,0 +1,9 @@
+Deface::Override.new(virtual_path: 'spree/admin/shared/_header',
+                    name: 'add-rma-button-to-sidebar',
+                    insert_bottom: "[data-hook='toolbar']",
+                    text: "
+                    <% if @order.completed? %>
+                      <li><%= button_link_to Spree.t('admin.orders.return_or_exchange'), admin_order_return_authorizations_path(@order) %>
+                    </li><% end %>
+                    ",
+                    enabled: true)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,7 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: Hello world
+  spree:
+    admin:
+      orders:
+        return_or_exchange: Return Or Exchange

--- a/solidus_quick_rma.gemspec
+++ b/solidus_quick_rma.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus_core', '~> 1.4'
   s.add_dependency 'solidus_backend', '~> 1.4'
+  s.add_dependency 'deface', '~> 1.0.2'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'
@@ -30,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'launchy'
 end

--- a/spec/features/admin/order_shipments_links_to_returns_spec.rb
+++ b/spec/features/admin/order_shipments_links_to_returns_spec.rb
@@ -9,6 +9,6 @@ RSpec.feature 'Return Button Under Order#edit', type: :feature do
   end
 
   scenario 'displays the button' do
-    expect(page).to have_content 'Return/Exchange'
+    expect(page).to have_content 'Return Or Exchange'
   end
 end

--- a/spec/features/admin/order_shipments_links_to_returns_spec.rb
+++ b/spec/features/admin/order_shipments_links_to_returns_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.feature 'Return Button Under Order#edit', type: :feature do
+  let!(:order) { create :shipped_order }
+  stub_authorization!
+
+  before :each do
+    visit spree.edit_admin_order_path(order)
+  end
+
+  scenario 'displays the button' do
+    expect(page).to have_content 'Return/Exchange'
+  end
+end


### PR DESCRIPTION
Links/buttons/etc to navigate from editing an order to the RMA/Return section of the Solidus admin.

[Clubhouse story](https://app.clubhouse.io/dynamomtl/story/50)
[Invision screen](https://projects.invisionapp.com/share/3Y8JIWFXV#/screens)
