### PR TITLE
RMA Admin Interface

### DIFF
--- a/app/assets/javascripts/spree/backend/return_authorizations/return_authorization_form_view.js
+++ b/app/assets/javascripts/spree/backend/return_authorizations/return_authorization_form_view.js
@@ -1,8 +1,15 @@
 var rmaView = Backbone.View.extend({
   el: '#new_authorized_return',
   template: HandlebarsTemplates['form'],
+
+  initialize: function(options) {
+    this.model = {
+      reasons: this.$el.data('reasons')
+    }
+  },
+
   render: function() {
-    this.$el.html(this.template())
+    this.$el.html(this.template(this.model))
     return this
   }
 });

--- a/app/assets/javascripts/spree/backend/return_authorizations/return_authorization_form_view.js
+++ b/app/assets/javascripts/spree/backend/return_authorizations/return_authorization_form_view.js
@@ -1,0 +1,8 @@
+var rmaView = Backbone.View.extend({
+  el: '#new_authorized_return',
+  template: HandlebarsTemplates['form'],
+  render: function() {
+    this.$el.html(this.template())
+    return this
+  }
+});

--- a/app/assets/javascripts/spree/backend/solidus_quick_rma.js
+++ b/app/assets/javascripts/spree/backend/solidus_quick_rma.js
@@ -1,2 +1,9 @@
 // Placeholder manifest file.
 // the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'
+//= require_tree ./templates
+//= require_tree ./return_authorizations
+
+$(function() {
+  formView = new rmaView();
+  formView.render();
+});

--- a/app/assets/javascripts/spree/backend/templates/form.hbs
+++ b/app/assets/javascripts/spree/backend/templates/form.hbs
@@ -1,5 +1,11 @@
 <fieldset>
   <legend>New Return</legend>
+  <label for="reasons">Reason for return/exchange</label>
+  <select id="return-reasons" name="reasons">
+    {{#each reasons}}
+      <option value="{{id}}">{{name}}</option>
+    {{/each}}
+  </select>
   <table>
     <thead></thead>
     <tbody>

--- a/app/assets/javascripts/spree/backend/templates/form.hbs
+++ b/app/assets/javascripts/spree/backend/templates/form.hbs
@@ -1,0 +1,13 @@
+<fieldset>
+  <legend>New Return</legend>
+  <table>
+    <thead></thead>
+    <tbody>
+      <form action="">
+        <tr>
+          <td></td>
+        </tr>
+      </form>
+    </tbody>
+  </table>
+</fieldset>

--- a/app/controllers/spree/admin/return_authorizations_controller_decorator.rb
+++ b/app/controllers/spree/admin/return_authorizations_controller_decorator.rb
@@ -1,0 +1,16 @@
+module Spree
+  module Admin
+    module ReturnAuthorizationsControllerDecorator
+      def self.prepended(base)
+        base.before_action :load_all_return_reasons, only: [:index]
+      end
+
+      private
+
+      def load_all_return_reasons
+        @reasons = Spree::ReturnReason.all
+      end
+    end
+  end
+end
+Spree::Admin::ReturnAuthorizationsController.prepend Spree::Admin::ReturnAuthorizationsControllerDecorator

--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -1,0 +1,8 @@
+module Spree
+  module InventoryUnitDecorator
+    def self.prepended(base)
+      base.delegate :name, to: :variant, prefix: :product
+    end
+  end
+end
+Spree::InventoryUnit.prepend Spree::InventoryUnitDecorator

--- a/app/overrides/admin/layouts/add_gon_to_admin_layout.rb
+++ b/app/overrides/admin/layouts/add_gon_to_admin_layout.rb
@@ -1,4 +1,0 @@
-Deface::Override.new(virtual_path: 'spree/layouts/admin',
-                    name: 'add-gon-to-admin-header',
-                    insert_bottom: "[data-hook='admin_insinde_head']",
-                    text: "<%= include_gon %>")

--- a/app/overrides/admin/layouts/add_gon_to_admin_layout.rb
+++ b/app/overrides/admin/layouts/add_gon_to_admin_layout.rb
@@ -1,0 +1,4 @@
+Deface::Override.new(virtual_path: 'spree/layouts/admin',
+                    name: 'add-gon-to-admin-header',
+                    insert_bottom: "[data-hook='admin_insinde_head']",
+                    text: "<%= include_gon %>")

--- a/app/overrides/admin/orders/add_rma_link_to_page_actions.rb
+++ b/app/overrides/admin/orders/add_rma_link_to_page_actions.rb
@@ -2,7 +2,7 @@ Deface::Override.new(virtual_path: 'spree/admin/shared/_header',
                     name: 'add-rma-button-to-sidebar',
                     insert_bottom: "[data-hook='toolbar']",
                     text: "
-                    <% if @order.completed? %>
+                    <% if @order && @order.completed? %>
                       <li><%= button_link_to Spree.t('admin.orders.return_or_exchange'), admin_order_return_authorizations_path(@order) %>
                     </li><% end %>
                     ",

--- a/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/app/views/spree/admin/return_authorizations/index.html.erb
@@ -1,0 +1,43 @@
+<%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
+
+<% content_for :page_actions do %>
+  <% if @order.shipments.any? &:shipped? %>
+    <li>
+      <% if can? :create, Spree::ReturnAuthorization %>
+        <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order) %>
+      <% end %>
+    </li>
+  <% end %>
+<% end %>
+
+<% admin_breadcrumb(plural_resource_name(Spree::ReturnAuthorization)) %>
+
+<% if @order.shipments.any?(&:shipped?) || @order.return_authorizations.any? %>
+  <fieldset>
+    <legend>Returns</legend>
+    <table class="index">
+      <thead data-hook="rma_header">
+        <tr>
+          <th><%= Spree::ReturnAuthorization.human_attribute_name(:number) %></th>
+          <th><%= Spree::ReturnAuthorization.human_attribute_name(:state) %></th>
+          <th><%= Spree::ReturnAuthorization.human_attribute_name(:pre_tax_total) %></th>
+          <th><%= Spree::ReturnAuthorization.human_attribute_name(:created_at) %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @return_authorizations.each do |return_authorization| %>
+          <tr id="<%= spree_dom_id(return_authorization) %>" data-hook="rma_row" class="<%= cycle('odd', 'even')%>">
+            <td><%= return_authorization.number %></td>
+            <td><%= Spree.t(return_authorization.state.downcase) %></td>
+            <td><%= return_authorization.display_pre_tax_total.to_html %></td>
+            <td><%= pretty_time(return_authorization.created_at) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </fieldset>
+<% else %>
+  <div data-hook="rma_cannot_create" class="no-objects-found">
+    <%= Spree.t(:cannot_create_returns) %>
+  </div>
+<% end %>

--- a/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/app/views/spree/admin/return_authorizations/index.html.erb
@@ -1,17 +1,5 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Return Authorizations' } %>
 
-<% content_for :page_actions do %>
-  <% if @order.shipments.any? &:shipped? %>
-    <li>
-      <% if can? :create, Spree::ReturnAuthorization %>
-        <%= button_link_to Spree.t(:new_return_authorization), new_admin_order_return_authorization_url(@order) %>
-      <% end %>
-    </li>
-  <% end %>
-<% end %>
-
-<% admin_breadcrumb(plural_resource_name(Spree::ReturnAuthorization)) %>
-
 <% if @order.shipments.any?(&:shipped?) || @order.return_authorizations.any? %>
   <fieldset>
     <legend>Returns</legend>
@@ -38,4 +26,7 @@
   </fieldset>
 <% end %>
 
-<div id="new_authorized_return"></div>
+<%= content_tag(:div, 
+                '',
+                id: 'new_authorized_return', 
+                data: { reasons: @reasons.to_json }) %>

--- a/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/app/views/spree/admin/return_authorizations/index.html.erb
@@ -37,3 +37,5 @@
     </table>
   </fieldset>
 <% end %>
+
+<div id="new_authorized_return"></div>

--- a/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/app/views/spree/admin/return_authorizations/index.html.erb
@@ -36,8 +36,4 @@
       </tbody>
     </table>
   </fieldset>
-<% else %>
-  <div data-hook="rma_cannot_create" class="no-objects-found">
-    <%= Spree.t(:cannot_create_returns) %>
-  </div>
 <% end %>

--- a/solidus_quick_rma.gemspec
+++ b/solidus_quick_rma.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', '~> 1.4'
   s.add_dependency 'solidus_backend', '~> 1.4'
   s.add_dependency 'deface', '~> 1.0.2'
-  s.add_dependency 'gon'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'

--- a/solidus_quick_rma.gemspec
+++ b/solidus_quick_rma.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'tzinfo-data'
+  s.add_development_dependency 'pry-byebug'
 end

--- a/solidus_quick_rma.gemspec
+++ b/solidus_quick_rma.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', '~> 1.4'
   s.add_dependency 'solidus_backend', '~> 1.4'
   s.add_dependency 'deface', '~> 1.0.2'
+  s.add_dependency 'gon'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'poltergeist'

--- a/spec/features/admin/new_return_authorization_form_spec.rb
+++ b/spec/features/admin/new_return_authorization_form_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.feature 'Return Authorization Listing Form', type: :feature, js: true do
+  let(:order) { create :shipped_order }
+  stub_authorization!
+
+  before :each do
+    visit spree.admin_order_return_authorizations_path(order)
+  end
+
+  scenario 'displays a form to initiate a new RMA/return' do
+    expect(page).to have_content 'New Return'
+  end
+end

--- a/spec/features/admin/new_return_authorization_form_spec.rb
+++ b/spec/features/admin/new_return_authorization_form_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.feature 'Return Authorization Listing Form', type: :feature, js: true do
   let(:order) { create :shipped_order }
+  let!(:reason) { create :return_reason }
   stub_authorization!
 
   before :each do
@@ -10,5 +11,15 @@ RSpec.feature 'Return Authorization Listing Form', type: :feature, js: true do
 
   scenario 'displays a form to initiate a new RMA/return' do
     expect(page).to have_content 'New Return'
+  end
+
+  feature 'reasons data attribute' do
+    scenario 'renders the data attribute correctly' do
+      expect(page.find('#new_authorized_return')['data-reasons']).to be_truthy
+    end
+
+    scenario 'embeds reasons into the data attribute' do
+      expect(page.find('#new_authorized_return')['data-reasons']).to include reason.name
+    end
   end
 end

--- a/spec/features/admin/new_return_authorization_form_spec.rb
+++ b/spec/features/admin/new_return_authorization_form_spec.rb
@@ -22,4 +22,10 @@ RSpec.feature 'Return Authorization Listing Form', type: :feature, js: true do
       expect(page.find('#new_authorized_return')['data-reasons']).to include reason.name
     end
   end
+
+  feature 'renders reason dropdown menu' do
+    scenario 'with options from the reasons data attribute' do
+      expect(page).to have_select('return-reasons', selected: reason.name)
+    end
+  end
 end

--- a/spec/features/admin/order_shipments_links_to_returns_spec.rb
+++ b/spec/features/admin/order_shipments_links_to_returns_spec.rb
@@ -16,4 +16,9 @@ RSpec.feature 'Return Button Under Order#edit', type: :feature do
     click_on 'Return Or Exchange'
     expect(page.current_url).to include "#{order.number}/return_authorizations"
   end
+
+  scenario 'only displays on order edit page' do
+    visit spree.admin_orders_path
+    expect(page).to_not have_content 'Return Or Exchange'
+  end
 end

--- a/spec/features/admin/order_shipments_links_to_returns_spec.rb
+++ b/spec/features/admin/order_shipments_links_to_returns_spec.rb
@@ -11,4 +11,9 @@ RSpec.feature 'Return Button Under Order#edit', type: :feature do
   scenario 'displays the button' do
     expect(page).to have_content 'Return Or Exchange'
   end
+
+  scenario 'clicks through to the rma/return section' do
+    click_on 'Return Or Exchange'
+    expect(page.current_url).to include "#{order.number}/return_authorizations"
+  end
 end

--- a/spec/models/spree/inventory_unit_spec.rb
+++ b/spec/models/spree/inventory_unit_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Spree::InventoryUnit, type: :model do
+  let!(:unit) { create :inventory_unit }
+
+  describe '#product_name' do
+    it 'returns the product name of the variant' do
+      expect(unit.product_name).to eq unit.variant.name
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ require File.expand_path('../dummy/config/environment.rb', __FILE__)
 require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,11 @@ require 'database_cleaner'
 require 'ffaker'
 require 'capybara/poltergeist'
 
-Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :poltergeist_debug do |app|
+  Capybara::Poltergeist::Driver.new(app, inspector: true)
+end
+
+Capybara.javascript_driver = :poltergeist_debug
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Redesign the RMA section of Spree Admin. This will house the base DOM elements to display and add an RMA/Return.

[Clubhouse Story](https://app.clubhouse.io/dynamomtl/story/50)
[Invision](https://projects.invisionapp.com/share/3Y8JIWFXV#/screens/186916310)

_Context_

This PR will encompass the first render of the new RMA form on the RMA listing page. Includes mostly form elements and Backbone work to wire up these elements/components. Since all work will be done on a single page and Backbone is offered for free in the admin, choose this to keep JS logic together and in check.
